### PR TITLE
Add XMACIS precipitation fetch script

### DIFF
--- a/bin/fetch_xmacis_precip.py
+++ b/bin/fetch_xmacis_precip.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+"""Fetch accumulated and normal precipitation from the XMACIS API."""
+
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+ROOT_DIR = Path(__file__).resolve().parent.parent
+if str(ROOT_DIR) not in sys.path:
+    sys.path.insert(0, str(ROOT_DIR))
+
+from lib.xmacis_client import (
+    XMACISAPIError,
+    XMACISClient,
+    start_of_water_year_iso,
+)
+
+
+def main() -> None:
+    if len(sys.argv) < 2:
+        raise SystemExit("Usage: fetch_xmacis_precip.py <STATION_ID>")
+
+    station = sys.argv[1]
+    start = start_of_water_year_iso()
+    end = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+
+    client = XMACISClient()
+    try:
+        response = client.fetch_precip_with_normals(station, start=start, end=end)
+    except XMACISAPIError as exc:
+        raise SystemExit(f"Failed to fetch precipitation data: {exc}")
+
+    print(json.dumps(response, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/lib/xmacis_client.py
+++ b/lib/xmacis_client.py
@@ -1,0 +1,113 @@
+"""Client for interacting with the XMACIS API."""
+
+from __future__ import annotations
+
+import json
+import urllib.parse
+import urllib.request
+from datetime import datetime, timezone
+from typing import Any, Dict
+from urllib.error import HTTPError, URLError
+
+
+class XMACISAPIError(Exception):
+    """Custom error for XMACIS API issues."""
+
+
+class XMACISClient:
+    """Simple client for fetching precipitation data from XMACIS."""
+
+    BASE_URL = "https://data.rcc-acis.org/StnData"
+
+    def __init__(self, timeout: int = 20) -> None:
+        self.timeout = timeout
+
+    def fetch_precip_with_normals(
+        self,
+        station: str,
+        *,
+        start: str,
+        end: str,
+    ) -> Dict[str, Any]:
+        """Fetch accumulated and normal precipitation from XMACIS.
+
+        Args:
+            station: Station identifier compatible with ACIS (e.g., "KSFO").
+            start: Start date in ``YYYY-MM-DD`` format.
+            end: End date in ``YYYY-MM-DD`` format.
+
+        Returns:
+            Parsed JSON response from the API.
+
+        Raises:
+            XMACISAPIError: When the API request fails or returns an error.
+        """
+
+        payload = {
+            "sid": station,
+            "sdate": start,
+            "edate": end,
+            "elems": [
+                {
+                    "name": "pcpn",
+                    "interval": "dly",
+                    "duration": "dly",
+                    "smry": {"reduce": "sum"},
+                    "smry_only": 1,
+                },
+                {
+                    "name": "pcpn",
+                    "interval": "dly",
+                    "duration": "dly",
+                    "smry": {"reduce": "sum"},
+                    "normal": 1,
+                    "smry_only": 1,
+                },
+            ],
+        }
+
+        data = urllib.parse.urlencode({"params": json.dumps(payload)})
+        req = urllib.request.Request(
+            self.BASE_URL,
+            data=data.encode("utf-8"),
+            headers={"Accept": "application/json"},
+            method="POST",
+        )
+
+        try:
+            with urllib.request.urlopen(req, timeout=self.timeout) as response:
+                if response.status != 200:
+                    raise XMACISAPIError(
+                        f"Request failed with status {response.status}: {response.read()}"
+                    )
+                parsed = json.loads(response.read().decode("utf-8"))
+        except HTTPError as exc:
+            body = exc.read()
+            details = body.decode("utf-8", errors="ignore") if body else exc.reason
+            raise XMACISAPIError(
+                f"HTTP error {exc.code} during API call: {details or 'no response body'}"
+            )
+        except URLError as exc:
+            raise XMACISAPIError(f"Network error during API call: {exc}")
+
+        if "error" in parsed:
+            raise XMACISAPIError(f"API error: {parsed['error']}")
+
+        return parsed
+
+
+def start_of_water_year_iso(now: datetime | None = None) -> str:
+    """Return the ACIS-friendly start date derived from ``start_date``.
+
+    The :func:`lib.synoptic_client.start_date` function returns ``YYYYMMDDHHMM``.
+    XMACIS expects dates in ``YYYY-MM-DD``; this helper bridges the formats.
+    """
+
+    if now is None:
+        now = datetime.now(timezone.utc)
+
+    from lib.synoptic_client import start_date
+
+    wateryear_start = start_date(now)
+    dt = datetime.strptime(wateryear_start, "%Y%m%d%H%M")
+    return dt.strftime("%Y-%m-%d")


### PR DESCRIPTION
## Summary
- add an XMACIS client to request accumulated and normal precipitation totals
- provide a CLI helper that fetches precipitation using the water-year start date from the synoptic client

## Testing
- pytest *(fails: ImportError: cannot import name '_extract_single_value' from 'src.data_processor')*


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6923478b38b8832d93b78704f0467a8e)