### PR TITLE
Add payload builder script and adjust fetchers

### DIFF
--- a/bin/build_station_payloads.py
+++ b/bin/build_station_payloads.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+"""Combine Synoptic station payloads with XMACIS precipitation summaries."""
+
+import json
+import sys
+from pathlib import Path
+
+ROOT_DIR = Path(__file__).resolve().parent.parent
+if str(ROOT_DIR) not in sys.path:
+    sys.path.insert(0, str(ROOT_DIR))
+
+from bin.fetch_synoptic_data import fetch_synoptic_data
+from bin.fetch_xmacis_precip import fetch_xmacis_precip
+from src.data_processor import build_station_payload
+
+DEFAULT_OUTPUT = Path("synoptic_stations.json")
+
+
+def main() -> None:
+    if len(sys.argv) < 2:
+        raise SystemExit(
+            "Usage: build_station_payloads.py <XMACIS_STATION> [OUTPUT_PATH]"
+        )
+
+    xmacis_station = sys.argv[1]
+    output_path = Path(sys.argv[2]) if len(sys.argv) > 2 else DEFAULT_OUTPUT
+
+    stationsA, stationsB, stationsC = fetch_synoptic_data()
+
+    payload_asos = build_station_payload(stationsA, stationsB, type="ASOS")
+    payload_hads = build_station_payload(stationsC, type="HADS")
+    combined = payload_asos + payload_hads
+
+    precip_summary = fetch_xmacis_precip(xmacis_station)
+
+    result = {
+        "stations": combined,
+        "xmacisSummary": precip_summary,
+    }
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(json.dumps(result, indent=2), encoding="utf-8")
+    print(f"Saved station payload and XMACIS summary to {output_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/bin/fetch_synoptic_data.py
+++ b/bin/fetch_synoptic_data.py
@@ -8,7 +8,6 @@ if str(ROOT_DIR) not in sys.path:
     sys.path.insert(0, str(ROOT_DIR))
 
 from lib.synoptic_client import SynopticClient, SynopticAPIError
-from src.data_processor import build_station_payload
 
 ASOS = [
     "KCCR",
@@ -29,10 +28,9 @@ HADS = [
     "CTOC1",
 ]
 
-OUTPUT_PATH = Path("synoptic_stations.json")
+def fetch_synoptic_data() -> tuple[list[dict], list[dict], list[dict]]:
+    """Fetch raw station responses from the Synoptic API."""
 
-
-def main() -> None:
     client = SynopticClient()
     try:
         responseA = client.fetch_latest(ASOS)
@@ -44,14 +42,19 @@ def main() -> None:
     stationsA = responseA.get("STATION", [])
     stationsB = responseB.get("STATION", [])
     stationsC = responseC.get("STATION", [])
-    payloadA = build_station_payload(stationsA, stationsB, type="ASOS")
-    payloadB = build_station_payload(stationsC, type="HADS")
+    return stationsA, stationsB, stationsC
 
-    combined = payloadA + payloadB
 
-    OUTPUT_PATH.parent.mkdir(parents=True, exist_ok=True)
-    OUTPUT_PATH.write_text(json.dumps(combined, indent=2), encoding="utf-8")
-    print(f"Saved data for {len(combined)} stations to {OUTPUT_PATH}")
+def main() -> None:
+    stationsA, stationsB, stationsC = fetch_synoptic_data()
+
+    payload = {
+        "stationsA": stationsA,
+        "stationsB": stationsB,
+        "stationsC": stationsC,
+    }
+
+    print(json.dumps(payload, indent=2))
 
 
 if __name__ == "__main__":

--- a/bin/fetch_xmacis_precip.py
+++ b/bin/fetch_xmacis_precip.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+"""Fetch accumulated and normal precipitation from the XMACIS API."""
+
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+ROOT_DIR = Path(__file__).resolve().parent.parent
+if str(ROOT_DIR) not in sys.path:
+    sys.path.insert(0, str(ROOT_DIR))
+
+from lib.xmacis_client import (
+    XMACISAPIError,
+    XMACISClient,
+    start_of_water_year_iso,
+)
+
+
+def fetch_xmacis_precip(station: str) -> list:
+    """Return only the precipitation summary for ``station``."""
+
+    start = start_of_water_year_iso()
+    end = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+
+    client = XMACISClient()
+    response = client.fetch_precip_with_normals(station, start=start, end=end)
+    return response.get("smry", [])
+
+
+def main() -> None:
+    if len(sys.argv) < 2:
+        raise SystemExit("Usage: fetch_xmacis_precip.py <STATION_ID>")
+
+    station = sys.argv[1]
+
+    try:
+        summary = fetch_xmacis_precip(station)
+    except XMACISAPIError as exc:
+        raise SystemExit(f"Failed to fetch precipitation data: {exc}")
+
+    print(json.dumps(summary, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/lib/xmacis_client.py
+++ b/lib/xmacis_client.py
@@ -1,0 +1,113 @@
+"""Client for interacting with the XMACIS API."""
+
+from __future__ import annotations
+
+import json
+import urllib.parse
+import urllib.request
+from datetime import datetime, timezone
+from typing import Any, Dict
+from urllib.error import HTTPError, URLError
+
+
+class XMACISAPIError(Exception):
+    """Custom error for XMACIS API issues."""
+
+
+class XMACISClient:
+    """Simple client for fetching precipitation data from XMACIS."""
+
+    BASE_URL = "https://data.rcc-acis.org/StnData"
+
+    def __init__(self, timeout: int = 20) -> None:
+        self.timeout = timeout
+
+    def fetch_precip_with_normals(
+        self,
+        station: str,
+        *,
+        start: str,
+        end: str,
+    ) -> Dict[str, Any]:
+        """Fetch accumulated and normal precipitation from XMACIS.
+
+        Args:
+            station: Station identifier compatible with ACIS (e.g., "KSFO").
+            start: Start date in ``YYYY-MM-DD`` format.
+            end: End date in ``YYYY-MM-DD`` format.
+
+        Returns:
+            Parsed JSON response from the API.
+
+        Raises:
+            XMACISAPIError: When the API request fails or returns an error.
+        """
+
+        payload = {
+            "sid": station,
+            "sdate": start,
+            "edate": end,
+            "elems": [
+                {
+                    "name": "pcpn",
+                    "interval": "dly",
+                    "duration": "dly",
+                    "smry": {"reduce": "sum"},
+                    "smry_only": 1,
+                },
+                {
+                    "name": "pcpn",
+                    "interval": "dly",
+                    "duration": "dly",
+                    "smry": {"reduce": "sum"},
+                    "normal": 1,
+                    "smry_only": 1,
+                },
+            ],
+        }
+
+        data = urllib.parse.urlencode({"params": json.dumps(payload)})
+        req = urllib.request.Request(
+            self.BASE_URL,
+            data=data.encode("utf-8"),
+            headers={"Accept": "application/json"},
+            method="POST",
+        )
+
+        try:
+            with urllib.request.urlopen(req, timeout=self.timeout) as response:
+                if response.status != 200:
+                    raise XMACISAPIError(
+                        f"Request failed with status {response.status}: {response.read()}"
+                    )
+                parsed = json.loads(response.read().decode("utf-8"))
+        except HTTPError as exc:
+            body = exc.read()
+            details = body.decode("utf-8", errors="ignore") if body else exc.reason
+            raise XMACISAPIError(
+                f"HTTP error {exc.code} during API call: {details or 'no response body'}"
+            )
+        except URLError as exc:
+            raise XMACISAPIError(f"Network error during API call: {exc}")
+
+        if "error" in parsed:
+            raise XMACISAPIError(f"API error: {parsed['error']}")
+
+        return parsed
+
+
+def start_of_water_year_iso(now: datetime | None = None) -> str:
+    """Return the ACIS-friendly start date derived from ``start_date``.
+
+    The :func:`lib.synoptic_client.start_date` function returns ``YYYYMMDDHHMM``.
+    XMACIS expects dates in ``YYYY-MM-DD``; this helper bridges the formats.
+    """
+
+    if now is None:
+        now = datetime.now(timezone.utc)
+
+    from lib.synoptic_client import start_date
+
+    wateryear_start = start_date(now)
+    dt = datetime.strptime(wateryear_start, "%Y%m%d%H%M")
+    return dt.strftime("%Y-%m-%d")


### PR DESCRIPTION
## Summary
- expose a reusable synoptic data fetcher that returns raw station responses
- adjust the XMACIS fetch script to return only precipitation summaries for reuse
- add a builder script that combines processed station payloads with the XMACIS summary output

## Testing
- not run (requires external API credentials)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6923478b38b8832d93b78704f0467a8e)