### PR TITLE
Add payload build script and refactor data fetchers

### DIFF
--- a/bin/build_station_payloads.py
+++ b/bin/build_station_payloads.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+"""Build payloads from Synoptic and XMACIS responses."""
+
+import json
+from pathlib import Path
+from typing import List, Dict, Any
+
+from bin.fetch_synoptic_data import fetch_synoptic_data
+from bin.fetch_xmacis_precip import fetch_xmacis_precip
+from src.data_processor import build_station_payload
+
+OUTPUT_PATH = Path("station_payloads.json")
+
+
+def build_payloads() -> Dict[str, Any]:
+    stationsA, stationsB, stationsC = fetch_synoptic_data()
+
+    payloadA = build_station_payload(stationsA, stationsB, type="ASOS")
+    payloadB = build_station_payload(stationsC, type="HADS")
+
+    precip_summary = fetch_xmacis_precip()
+
+    combined: List[Dict[str, Any]] = payloadA + payloadB
+
+    return {
+        "stations": combined,
+        "precipSummary": precip_summary,
+    }
+
+
+def main() -> None:
+    payloads = build_payloads()
+
+    OUTPUT_PATH.parent.mkdir(parents=True, exist_ok=True)
+    OUTPUT_PATH.write_text(json.dumps(payloads, indent=2), encoding="utf-8")
+
+    print(
+        f"Saved station payload and precipitation summary "
+        f"to {OUTPUT_PATH}"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/bin/fetch_xmacis_precip.py
+++ b/bin/fetch_xmacis_precip.py
@@ -29,8 +29,8 @@ stations = load_station_ids()
 ASOS: List[str] = stations.get("ASOS", [])
 HADS: List[str] = stations.get("HADS", [])
 
-def main() -> None:
 
+def fetch_xmacis_precip() -> List:
     start = start_of_water_year_iso()
     end = datetime.now(timezone.utc).strftime("%Y-%m-%d")
 
@@ -40,7 +40,12 @@ def main() -> None:
     except XMACISAPIError as exc:
         raise SystemExit(f"Failed to fetch precipitation data: {exc}")
 
-    vals = response.get("smry", [])
+    return response.get("smry", [])
+
+
+def main() -> None:
+    vals = fetch_xmacis_precip()
+    print(f"Fetched {len(vals)} precipitation summary entries from XMACIS.")
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Summary
- refactor the synoptic and XMACIS fetch scripts to return raw response data for reuse
- add a new build script that assembles station payloads and includes precipitation summaries in a single output

## Testing
- python -m pytest *(fails: ImportError: cannot import name '_extract_single_value' from 'src.data_processor')*


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69235cad00ec832da0a386b49eb61f07)